### PR TITLE
Use a callback/event drive setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "wifi.c"
-                    INCLUDE_DIRS "include")
+                    INCLUDE_DIRS "include"
+                    )

--- a/include/wifi.h
+++ b/include/wifi.h
@@ -7,7 +7,9 @@ typedef enum _wifi_manager_state
 {
   WIFI_STATE_DISCONNECTED,
   WIFI_STATE_CONNECTING,
-  WIFI_STATE_CONNECTED
+  WIFI_STATE_CONNECTED,
+  WIFI_STATE_AP_STARTING,
+  WIFI_STATE_AP_STARTED
 } wifi_manager_state_t;
 
 typedef enum _wifi_events
@@ -17,7 +19,12 @@ typedef enum _wifi_events
   WIFI_CONNECTED,
   WIFI_CONNECT_FAIL,
   WIFI_DISCONNECTED,
-  WIFI_DISCONNECT_FAIL
+  WIFI_DISCONNECT_FAIL,
+
+  WIFI_AP_STARTED,
+  WIFI_AP_STOPPED,
+  WIFI_AP_CONNECTED,
+  WIFI_AP_DISCONNECTED,
 } wifi_events_t;
 
 typedef struct _wifi_manager
@@ -37,6 +44,8 @@ typedef struct _wifi_callbacks_t
 void wifi_init(wifi_callbacks_t *callbacks);
 void wifi_connect_ssid(const char *ssid, const char *password);
 void wifi_disconnect();
+void wifi_start_soft_ap(const char *ssid, const char *password);
+void wifi_stop_soft_ap();
 void wifi_uninit();
 
 wifi_manager_state_t wifi_get_state();

--- a/include/wifi.h
+++ b/include/wifi.h
@@ -1,14 +1,43 @@
-#ifndef _PROVIDORE_WIFI_SERVICE_h
-#define _PROVIDORE_WIFI_SERVICE_h
+#ifndef _PROVIDORE_WIFI_MANAGER_h
+#define _PROVIDORE_WIFI_MANAGER_h
 #include "esp_wifi.h"
 #include "freertos/event_groups.h"
 
-typedef void (*wifi_on_connect)();
+typedef enum _wifi_manager_state
+{
+  WIFI_STATE_DISCONNECTED,
+  WIFI_STATE_CONNECTING,
+  WIFI_STATE_CONNECTED
+} wifi_manager_state_t;
+
+typedef enum _wifi_events
+{
+  WIFI_CONNECTING,
+  WIFI_RETRYING,
+  WIFI_CONNECTED,
+  WIFI_CONNECT_FAIL,
+  WIFI_DISCONNECTED,
+  WIFI_DISCONNECT_FAIL
+} wifi_events_t;
+
+typedef struct _wifi_manager
+{
+  wifi_manager_state_t state;
+  wifi_manager_state_t desired_state;
+  uint8_t retries;
+  esp_ip_addr_t ip;
+} wifi_manager_t;
+
+typedef void (*wifi_event_listener)(wifi_manager_t *wifi_manager, wifi_events_t event, void *event_data);
 typedef struct _wifi_callbacks_t
 {
-  wifi_on_connect on_connect;
+  wifi_event_listener on_event;
 } wifi_callbacks_t;
 
 void wifi_init(wifi_callbacks_t *callbacks);
-void wifi_init_sta(const char *ssid, const char *password);
+void wifi_connect_ssid(const char *ssid, const char *password);
+void wifi_disconnect();
+void wifi_uninit();
+
+wifi_manager_state_t wifi_get_state();
 #endif


### PR DESCRIPTION
Handle reconnects more gracefully and allow caller to listen to status updates. Break the API in a big way.